### PR TITLE
Aug26 alignment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ delete*
 ignore*
 # VSCode
 .vscode
+vagrant
 
 # Byte-compiled / optimized / DLL files
 __pycache__/
@@ -43,3 +44,29 @@ benchparse/
 
 # GitHub Action/Workflow files
 .github/
+
+# Secret/key files
+*.vault
+*.key
+*.pem
+*.p12
+*.pfx
+*.keystore
+*.jks
+*.credentials
+*vault_pass*
+.vault_pass
+
+# QA/temp artifacts
+qa_report.md
+*qa_report*
+prompt.md
+plan.md
+history.md
+*history.md
+*plan.md
+test_inv
+*.pdf
+
+# ansible-lint
+.ansible/

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,21 @@
 # Changes to Ubuntu22-CIS-Audit
 
+## [v3.00_aug26] - based upon CIS v3.0.0
+
+- v3.00_aug26 branch
+  - 1.6.1: invalid YAML escapes aborted the audit
+  - 1.7.2: banner quote collision aborted the audit
+  - 3.1.1: misindented file key, CIS_ID corrected
+  - 3.1.2 and 5.4.2.8: process substitution removed, dash safe
+  - 7.2.3: /tmp writes removed, audit read only again
+  - goss.yml: IPv6 include glob corrected, eight checks were unreachable
+  - Rule IDs corrected in gates, titles and CIS_ID metadata
+  - run_audit.sh: goss version parse fixed, aligned to latest version
+  - Minimum goss version raised to 0.5.0
+  - Titles updated for alignment
+  - README goss links and version updated
+  - gitignore patterns added, spelling corrected
+
 ## [2026_April_QA] - based upon CIS v3.0.0
 
 ### QA Validation

--- a/Changelog.md
+++ b/Changelog.md
@@ -15,6 +15,7 @@
   - Titles updated for alignment
   - README goss links and version updated
   - gitignore patterns added, spelling corrected
+  - several tests fixed
 
 ## [2026_April_QA] - based upon CIS v3.0.0
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Goss is run based on the goss.yml file in the top level directory. This specifie
 
 ## Requirements
 
-You must have [goss](https://github.com/goss-org/goss/) available to your host you would like to test.
+You must have [goss](https://github.com/krameff/goss/) >= 0.5.0 available to your host you would like to test.
 
 You must have sudo/root access to the system as some commands require privilege information.
 
@@ -37,14 +37,8 @@ Which will:
 
 On our [Discord Server](https://www.lockdownenterprise.com/discord) to ask questions, discuss features, or just chat with other Ansible-Lockdown users
 
-Set of configuration files and directories to run the first stages of CIS of UBUNTU 22 servers
-
-This is configured in a directory structure level.
-
-Goss is run based on the goss.yml file in the top level directory. This specifies the configuration.
-
 ## further information
 
 - [ReadtheDocs](https://ansible-lockdown.readthedocs.io/en/stable/)
-- [goss documentation](https://github.com/aelsabbahy/goss/blob/master/docs/manual.md#patterns)
+- [goss documentation](https://github.com/krameff/goss/blob/master/README.md)
 - [CIS standards](https://www.cisecurity.org)

--- a/goss.yml
+++ b/goss.yml
@@ -22,7 +22,7 @@ gossfile:
   section_3/cis_3.2/*.yml: {}
   section_3/cis_3.3.1/*.yml: {}
     {{ if .Vars.ubtu22cis_ipv6_required }}
-  section_3/cis_3.3.2/ipv6/*.yml: {}
+  section_3/cis_3.3.2/*.yml: {}
     {{ end }}
   {{ end }}
 

--- a/run_audit.sh
+++ b/run_audit.sh
@@ -19,8 +19,10 @@
 # April 2024    Updating of OS discovery to work for all supported OSs
 # August 2024   Improve failure capture
 # January 2025  Added Suse OS discovery
-# May 2025      Added formation typos to help and fixed some typos
+# May 2025      Added format option to help and fixed some typos
 # Sept25        Added Additional max concurrent process option
+# June 2026     Changed OS discovery to use BENCHMARK_OS variable to allow for future OS discovery and audit alignment
+# July 2026     Updated goss version discovery
 # Variables in upper case tend to be able to be adjusted
 # lower case variables are discovered or built from other variables
 
@@ -31,7 +33,7 @@ BENCHMARK_OS=UBUNTU22
 
 # Goss host Variables
 AUDIT_BIN="${AUDIT_BIN:-/usr/local/bin/goss}"  # location of the goss executable
-AUDIT_BIN_MIN_VER="0.4.4"
+AUDIT_BIN_MIN_VER="0.5.0"
 AUDIT_FILE="${AUDIT_FILE:-goss.yml}"  # the default goss file used by the audit provided by the audit configuration
 AUDIT_CONTENT_LOCATION="${AUDIT_CONTENT_LOCATION:-/opt}"  # Location of the audit configuration file as available to the OS
 
@@ -79,27 +81,13 @@ done
 
 # check access need to run as root or privileges due to some configuration access
 if [ "$(/usr/bin/id -u)" -ne 0 ]; then
-  echo "Script need to run with root privileges"
+  echo "Script needs to run with root privileges"
   exit 1
 fi
 
 #### Main Script ####
 
-# Discover OS version aligning with audit
-# Define os_vendor variable
-if [ "$(uname -a | grep -c amzn)" -ge 1 ]; then
-    os_vendor="AMAZON"
-elif [ "$(grep -Ec "rhel|oracle" /etc/os-release)" != 0 ]; then
-  os_vendor="RHEL"
-else
-  os_vendor="$(hostnamectl | grep Oper | cut -d : -f2 | awk '{print toupper($1)}')"
-  if [ "${os_vendor}" = "OPENSUSE" ]; then
-   os_vendor="SUSE"
-  fi
-fi
-
-os_maj_ver="$(grep -w VERSION_ID= /etc/os-release | awk -F\" '{print $2}' | cut -d '.' -f1)"
-audit_content_version=$os_vendor$os_maj_ver-$BENCHMARK-Audit
+audit_content_version=$BENCHMARK_OS-$BENCHMARK-Audit
 audit_content_dir=$AUDIT_CONTENT_LOCATION/$audit_content_version
 audit_vars=vars/${BENCHMARK}.yml
 
@@ -164,12 +152,12 @@ echo
 export FAILURE=0
 if [ -s "${AUDIT_BIN}" ]; then
   echo "OK - Audit binary $AUDIT_BIN is available"
-  goss_installed_version="$($AUDIT_BIN -v | awk '{print $NF}' | cut -dv -f2)"
+  goss_installed_version="$($AUDIT_BIN -v | awk 'NR==1{print $NF}' | cut -dv -f2)"
   newer_version=$(echo -e "$goss_installed_version\n$AUDIT_BIN_MIN_VER" | sort -V | tail -n 1)
   if [ "$goss_installed_version" = "$newer_version" ] || [ "$goss_installed_version" = "$AUDIT_BIN_MIN_VER" ]; then
     echo "OK - Goss is installed and version is ok ($goss_installed_version >= $AUDIT_BIN_MIN_VER)"
   else
-    echo "WARNING - Goss installed = ${goss_installed_version}, does not met minimum of ${AUDIT_BIN_MIN_VER}"
+    echo "WARNING - Goss installed = ${goss_installed_version}, does not meet minimum of ${AUDIT_BIN_MIN_VER}"
     export FAILURE=2
   fi
 else

--- a/section_1/cis_1.3.1/cis_1.3.1.1.yml
+++ b/section_1/cis_1.3.1/cis_1.3.1.1.yml
@@ -4,7 +4,7 @@
   {{ if .Vars.ubtu22cis_rule_1_3_1_1 }}
 package:
   apparmor:
-    title: 1.3.1.1 | Ensure AppArmor is installed
+    title: 1.3.1.1 | Ensure the apparmor packages are installed
     installed: true
     name: apparmor
     meta:

--- a/section_1/cis_1.3.1/cis_1.3.1.2.yml
+++ b/section_1/cis_1.3.1/cis_1.3.1.2.yml
@@ -4,7 +4,7 @@
   {{ if .Vars.ubtu22cis_rule_1_3_1_2 }}
 file:
   apparmor_boot_grub:
-    title: 1.3.1.2 | Ensure AppArmor is enabled in the bootloader configuration | running grub
+    title: 1.3.1.2 | Ensure AppArmor is enabled | running grub
     path: /boot/grub/grub.cfg
     exists: true
     contents:
@@ -18,7 +18,7 @@ file:
       - 1.3.1.2
       NIST800-53R5: AC-3
   grub_app_armor:
-    title: 1.3.1.2 | Ensure AppArmor is enabled in the bootloader configuration | default grub
+    title: 1.3.1.2 | Ensure AppArmor is enabled | default grub
     exists: true
     path: /etc/default/grub
     contents:

--- a/section_1/cis_1.3.1/cis_1.3.1.3.yml
+++ b/section_1/cis_1.3.1/cis_1.3.1.3.yml
@@ -5,7 +5,7 @@
   {{ if .Vars.ubtu22cis_rule_1_3_1_3 }}
 command:
   apparmor_enf_or_comp:
-    title: 1.3.1.3 | Ensure all AppArmor Profiles are in enforce or complain mode | profile
+    title: 1.3.1.3 | Ensure all AppArmor Profiles are not disabled | profile
     exec: LOADED=`apparmor_status | grep 'profiles are loaded' | awk '{print $1}'` && ENFORCE=`apparmor_status | grep 'profiles are in enforce mode.' | awk '{print $1}'` && COMPLAIN=`apparmor_status | grep 'profiles are in complain mode.' | awk '{print $1}'` && if [ $((ENFORCE + COMPLAIN)) != "$LOADED" ]; then echo "Profiles Error";fi
     exit-status: 0
     stdout:

--- a/section_1/cis_1.4/cis_1.4.2.yml
+++ b/section_1/cis_1.4/cis_1.4.2.yml
@@ -4,7 +4,7 @@
   {{ if .Vars.ubtu22cis_rule_1_4_2 }}
 file:
   default_grub_perms:
-    title: 1.4.2 | Ensure access to bootloader if configured
+    title: 1.4.2 | Ensure access to bootloader config is configured
     exists: true
     path: /boot/grub/grub.cfg
     owner: root

--- a/section_1/cis_1.5/cis_1.5.2.yml
+++ b/section_1/cis_1.5/cis_1.5.2.yml
@@ -5,7 +5,7 @@
 kernel-param:
   kernel.yama.ptrace_scope:
     title: 1.5.2 | Ensure ptrace_scope is configured | sysctl_live
-    value: '[1-3]'
+    value: '{{ .Vars.ubtu22cis_ptrace_scope }}'
     meta:
       server: 1
       workstation: 1

--- a/section_1/cis_1.5/cis_1.5.3.yml
+++ b/section_1/cis_1.5/cis_1.5.3.yml
@@ -4,7 +4,7 @@
   {{ if .Vars.ubtu22cis_rule_1_5_3 }}
 command:
   suid_dumpable_2:
-    title: 1.5.3 | Ensure core dumps are restricted | sysctl.conf
+    title: 1.5.3 | Ensure suid_dumpable is configured | sysctl.conf
     exit-status: 0
     exec: 'grep "fs\.suid_dumpable" /etc/sysctl.conf /etc/sysctl.d/*'
     stdout:
@@ -17,7 +17,7 @@ command:
       NIST800-53R5: NA
 kernel-param:
   fs.suid_dumpable:
-    title: 1.5.3 | Ensure core dumps are restricted | kernel_sysctl
+    title: 1.5.3 | Ensure suid_dumpable is configured | kernel_sysctl
     value: '0'
     meta:
       server: 1

--- a/section_1/cis_1.5/cis_1.5.4.yml
+++ b/section_1/cis_1.5/cis_1.5.4.yml
@@ -4,7 +4,7 @@
   {{ if .Vars.ubtu22cis_rule_1_5_4 }}
 command:
   core_dumps_limits:
-    title: 1.5.4 | Ensure core dumps are restricted | security/limits.conf
+    title: 1.5.4 | Ensure core file size is configured | security/limits.conf
     exit-status:
       or:
       - 0

--- a/section_1/cis_1.5/cis_1.5.6.yml
+++ b/section_1/cis_1.5/cis_1.5.6.yml
@@ -4,7 +4,7 @@
   {{ if .Vars.ubtu22cis_rule_1_5_6 }}
 package:
   apport:
-    title: 1.5.6 | Ensure Automatic Error Reporting is not enabled | Package
+    title: 1.5.6 | Ensure Automatic Error Reporting is configured | Package
     installed: false
     meta:
       server: 1
@@ -13,7 +13,7 @@ package:
       - 1.5.6
 file:
   error_report_apport_disable:
-    title: 1.5.6 | Ensure Automatic Error Reporting is not enabled | disabled
+    title: 1.5.6 | Ensure Automatic Error Reporting is configured | disabled
     exists: true
     path: /etc/default/apport
     contents:

--- a/section_1/cis_1.6/cis_1.6.1.yml
+++ b/section_1/cis_1.6/cis_1.6.1.yml
@@ -48,7 +48,7 @@ file:
 command:
   check_motd_files:
     title: 1.6.1 | Ensure /etc/motd is configured | dynamic motd files
-    exec: "grep -Eis \"(\\\v|\\\r|\\\m|\\\s|$(grep '^ID=' /etc/os-release | cut -d= -f2 | sed -e 's/\"//g'))\" /etc/update-motd.d/*"
+    exec: 'grep -Eis "(\\v|\\r|\\m|\\s|$(grep ''^ID='' /etc/os-release | cut -d= -f2 | sed -e ''s/"//g''))" /etc/update-motd.d/*'
     exit-status:
       or:
       - 0

--- a/section_1/cis_1.6/cis_1.6.4.yml
+++ b/section_1/cis_1.6/cis_1.6.4.yml
@@ -4,7 +4,7 @@
   {{ if .Vars.ubtu22cis_rule_1_6_4 }}
 file:
   motd_perms:
-    title: 1.7.4 | Ensure access to /etc/motd is configured
+    title: 1.6.4 | Ensure access to /etc/motd is configured
     path: /etc/motd
     exists:
       or:

--- a/section_1/cis_1.6/cis_1.6.5.yml
+++ b/section_1/cis_1.6/cis_1.6.5.yml
@@ -4,7 +4,7 @@
   {{ if .Vars.ubtu22cis_rule_1_6_5 }}
 file:
   etc_issue_perms:
-    title: 1.6.5 | Ensure acces to /etc/issue is configured
+    title: 1.6.5 | Ensure access to /etc/issue is configured
     exists: true
     path: /etc/issue
     owner: root

--- a/section_1/cis_1.7/cis_1.7.1.yml
+++ b/section_1/cis_1.7/cis_1.7.1.yml
@@ -5,7 +5,7 @@
     {{ if .Vars.ubtu22cis_rule_1_7_1 }}
 package:
   gdm3:
-    title: 1.7.1 | Ensure GNOME Display Manager is removed
+    title: 1.7.1 | Ensure GDM is removed
     installed: false
     meta:
       server: 2

--- a/section_1/cis_1.7/cis_1.7.10.yml
+++ b/section_1/cis_1.7/cis_1.7.10.yml
@@ -5,7 +5,7 @@
     {{ if .Vars.ubtu22cis_rule_1_7_10 }}
 file:
   gdm_xdcmp:
-    title: 1.7.10 | Ensure XDCMP is not enabled
+    title: 1.7.10 | Ensure XDMCP is not enabled
     path: /etc/gdm3/custom.conf
     exists: true
     contents:

--- a/section_1/cis_1.7/cis_1.7.11.yml
+++ b/section_1/cis_1.7/cis_1.7.11.yml
@@ -2,10 +2,10 @@
 
 {{ if .Vars.ubtu22cis_level_2 }}
   {{ if .Vars.ubtu22cis_desktop_required }}
-    {{ if .Vars.ubtu22cis_rule_1_7_10 }}
+    {{ if .Vars.ubtu22cis_rule_1_7_11 }}
 file:
   /etc/gdm/custom.conf:
-    title: 1.8.7 | Ensure Xwayland is configured
+    title: 1.7.11 | Ensure Xwayland is configured
     path: /etc/gdm/custom.conf
     exists: true
     contents:

--- a/section_1/cis_1.7/cis_1.7.2.yml
+++ b/section_1/cis_1.7/cis_1.7.2.yml
@@ -11,7 +11,7 @@ file:
     contents:
     - '/^[org/gnome/login-screen]/'
     - '/^banner-message-enable=true/'
-    - '/^banner-message-text='{{ .Vars.ubtu22cis_warning_banner }}'/'
+    - "/^banner-message-text='{{ .Vars.ubtu22cis_warning_banner }}'/"
     meta:
       server: 1
       workstation: 1

--- a/section_1/cis_1.7/cis_1.7.3.yml
+++ b/section_1/cis_1.7/cis_1.7.3.yml
@@ -5,7 +5,7 @@
     {{ if .Vars.ubtu22cis_rule_1_7_3 }}
 command:
   gdm_disable_user:
-    title: 1.7.3 | Ensure disable-user-list is enabled
+    title: 1.7.3 | Ensure GDM disable-user-list option is enabled
     exec: grep -E "^disable-user-list" /etc/gdm3/greeter.dconf-defaults
     exit-status: 0
     stdout:

--- a/section_2/cis_2.1/cis_2.1.12.yml
+++ b/section_2/cis_2.1/cis_2.1.12.yml
@@ -21,7 +21,7 @@ package:
       {{ if .Vars.ubtu22cis_rpc_mask }}
 file:
   rpcbind_service_masked:
-    title: 2.1.12 | Ensure rpc services are not in use | masked
+    title: 2.1.12 | Ensure rpcbind services are not in use | masked
     path: /etc/systemd/system/rpcbind.service
     exists: true
     filetype: symlink
@@ -35,7 +35,7 @@ file:
       - CM-6
       - CM-7
   rpcbind_socket_masked:
-    title: 2.1.12 | Ensure rpc services are not in use | masked
+    title: 2.1.12 | Ensure rpcbind services are not in use | masked
     path: /etc/systemd/system/rpcbind.socket
     exists: true
     filetype: symlink

--- a/section_2/cis_2.1/cis_2.1.14.yml
+++ b/section_2/cis_2.1/cis_2.1.14.yml
@@ -21,7 +21,7 @@ package:
   {{ if .Vars.ubtu22cis_samba_mask }}
 file:
   samba_service_masked:
-    title: 2.1.14 | Ensure samba server services are not in use | masked
+    title: 2.1.14 | Ensure samba file server services are not in use | masked
     path: /etc/systemd/system/smbd.service
     exists: true
     filetype: symlink

--- a/section_2/cis_2.1/cis_2.1.21.yml
+++ b/section_2/cis_2.1/cis_2.1.21.yml
@@ -18,7 +18,7 @@ command:
       - CM-7
 file:
   /etc/postfix/main.conf:
-    title: 2.1.21 | Ensure mail transfer agent is configured for local-only mode
+    title: 2.1.21 | Ensure mail transfer agents are configured for local-only mode
     exists: true
     contents:
     - '/^inet_interfaces\s*=\s*loopback-only/'

--- a/section_2/cis_2.1/cis_2.1.5.yml
+++ b/section_2/cis_2.1/cis_2.1.5.yml
@@ -6,7 +6,7 @@
       {{ if not .Vars.ubtu22cis_dnsmasq_mask }}
 package:
   dnsmasq_pkg:
-    title: 2.1.5 | Ensure dnsmasq server services are not in use | pkg removed
+    title: 2.1.5 | Ensure dnsmasq services are not in use | pkg removed
     name: dnsmasq
     installed: false
     meta:
@@ -20,7 +20,7 @@ package:
       {{ if .Vars.ubtu22cis_dnsmasq_mask }}
 file:
   dnsmasq_service_masked:
-    title: 2.1.5 | Ensure dnsmasq server services are not in use | masked
+    title: 2.1.5 | Ensure dnsmasq services are not in use | masked
     path: /etc/systemd/system/dnsmasq.service
     exists: true
     filetype: symlink

--- a/section_2/cis_2.2/cis_2.2.1.yml
+++ b/section_2/cis_2.2/cis_2.2.1.yml
@@ -5,7 +5,7 @@
     {{ if .Vars.ubtu22cis_rule_2_2_1 }}
 package:
   nis_client:
-    title: 2.2.1 | Ensure NIS Client is not installed
+    title: 2.2.1 | Ensure nis client is not installed
     installed: false
     name: nis
     meta:

--- a/section_2/cis_2.2/cis_2.2.5.yml
+++ b/section_2/cis_2.2/cis_2.2.5.yml
@@ -5,7 +5,7 @@
     {{ if .Vars.ubtu22cis_rule_2_2_5 }}
 package:
   ldap-utils:
-    title: 2.2.5 | Ensure LDAP client is not installed
+    title: 2.2.5 | Ensure ldap client is not installed
     installed: false
     name: ldap-utils
     meta:

--- a/section_2/cis_2.3/cis_2.3.1.1.yml
+++ b/section_2/cis_2.3/cis_2.3.1.1.yml
@@ -15,7 +15,7 @@ package:
       - AU-12
   {{ if eq .Vars.ubtu22cis_time_sync_tool "systemd-timesyncd" }}
   ntp:
-    title: 2.3.1.1 | Ensure time synchronization is in use | ntp service
+    title: 2.3.1.1 | Ensure a single time synchronization daemon is in use | ntp service
     installed: false
     meta:
       server: 1
@@ -25,7 +25,7 @@ package:
       - AU-3
       - AU-12
   chrony:
-    title: 2.3.1.1 | Ensure time synchronization is in use | chrony service
+    title: 2.3.1.1 | Ensure a single time synchronization daemon is in use | chrony service
     installed: false
     meta:
       server: 1
@@ -38,7 +38,7 @@ package:
   {{ if ne .Vars.ubtu22cis_time_sync_tool "systemd-timesyncd" }}
 file:
   timesync_masked:
-    title: 2.3.1.1 | Ensure time synchronization is in use | systemd-timesyncd masked
+    title: 2.3.1.1 | Ensure a single time synchronization daemon is in use | systemd-timesyncd masked
     path: /etc/systemd/system/systemd-timesyncd.service
     filetype: symlink
     linked-to: /dev/null

--- a/section_2/cis_2.4/cis_2.4.1.1.yml
+++ b/section_2/cis_2.4/cis_2.4.1.1.yml
@@ -20,7 +20,7 @@ package:
       - IA-5
 service:
   cron:
-    title: 2.4.1.1 | Ensure cron daemon is enabled and running | service
+    title: 2.4.1.1 | Ensure cron daemon is enabled and active | service
     running: true
     enabled: true
     meta:

--- a/section_2/cis_2.4/cis_2.4.1.2.yml
+++ b/section_2/cis_2.4/cis_2.4.1.2.yml
@@ -4,7 +4,7 @@
   {{ if .Vars.ubtu22cis_rule_2_4_1_2 }}
 file:
   crontab_perms:
-    title: 2.4.1.2 | Ensure permissions on /etc/crontab are configured
+    title: 2.4.1.2 | Ensure access to /etc/crontab is configured
     path: /etc/crontab
     exists: true
     owner: root

--- a/section_2/cis_2.4/cis_2.4.1.3.yml
+++ b/section_2/cis_2.4/cis_2.4.1.3.yml
@@ -4,7 +4,7 @@
   {{ if .Vars.ubtu22cis_rule_2_4_1_3 }}
 file:
   cron_hourly_perms:
-    title: 2.4.1.3 | Ensure permissions on /etc/cron.hourly are configured
+    title: 2.4.1.3 | Ensure access to /etc/cron.hourly is configured
     path: /etc/cron.hourly
     exists: true
     owner: root

--- a/section_2/cis_2.4/cis_2.4.1.4.yml
+++ b/section_2/cis_2.4/cis_2.4.1.4.yml
@@ -4,7 +4,7 @@
   {{ if .Vars.ubtu22cis_rule_2_4_1_4 }}
 file:
   cron_daily_perms:
-    title: 2.4.1.4 | Ensure permissions on /etc/cron.daily are configured
+    title: 2.4.1.4 | Ensure access to /etc/cron.daily is configured
     path: /etc/cron.daily
     exists: true
     owner: root

--- a/section_2/cis_2.4/cis_2.4.1.5.yml
+++ b/section_2/cis_2.4/cis_2.4.1.5.yml
@@ -4,7 +4,7 @@
   {{ if .Vars.ubtu22cis_rule_2_4_1_5 }}
 file:
   cron_weekly_perms:
-    title: 2.4.1.5 | Ensure permissions on /etc/cron.weekly are configured
+    title: 2.4.1.5 | Ensure access to /etc/cron.weekly is configured
     path: /etc/cron.weekly
     exists: true
     owner: root

--- a/section_2/cis_2.4/cis_2.4.1.6.yml
+++ b/section_2/cis_2.4/cis_2.4.1.6.yml
@@ -4,7 +4,7 @@
   {{ if .Vars.ubtu22cis_rule_2_4_1_6 }}
 file:
   cron_monthly_perms:
-    title: 2.4.1.6 | Ensure permissions on /etc/cron.monthly are configured
+    title: 2.4.1.6 | Ensure access to /etc/cron.monthly is configured
     path: /etc/cron.monthly
     exists: true
     owner: root

--- a/section_2/cis_2.4/cis_2.4.1.7.yml
+++ b/section_2/cis_2.4/cis_2.4.1.7.yml
@@ -4,7 +4,7 @@
   {{ if .Vars.ubtu22cis_rule_2_4_1_7 }}
 file:
   cron_yearly_perms:
-    title: 2.4.1.7 | Ensure permissions on /etc/cron.yearly are configured
+    title: 2.4.1.7 | Ensure access to /etc/cron.yearly is configured
     path: /etc/cron.yearly
     exists: true
     owner: root

--- a/section_2/cis_2.4/cis_2.4.1.8.yml
+++ b/section_2/cis_2.4/cis_2.4.1.8.yml
@@ -4,7 +4,7 @@
   {{ if .Vars.ubtu22cis_rule_2_4_1_8 }}
 file:
   cron_d_perms:
-    title: 2.4.1.8 | Ensure permissions on /etc/cron.d are configured
+    title: 2.4.1.8 | Ensure access to /etc/cron.d is configured
     path: /etc/cron.d
     exists: true
     owner: root

--- a/section_2/cis_2.4/cis_2.4.1.9.yml
+++ b/section_2/cis_2.4/cis_2.4.1.9.yml
@@ -4,19 +4,19 @@
   {{ if .Vars.ubtu22cis_rule_2_4_1_9 }}
 file:
   cron_deny_absent:
-    title: 2.4.1.9 | Ensure cron is restricted to authorized users
+    title: 2.4.1.9 | Ensure access to crontab is configured
     path: /etc/cron.deny
     exists: false
     meta:
       server: 1
       workstation: 1
       CIS_ID:
-      - 2.4.1.8
+      - 2.4.1.9
       NIST800-53R5:
       - AC-3
       - MP-2
   /etc/cron.allow:
-    title: 2.4.1.9 | Ensure cron is restricted to authorized users
+    title: 2.4.1.9 | Ensure access to crontab is configured
     exists: true
     owner: root
     group: root

--- a/section_2/cis_2.4/cis_2.4.2.1.yml
+++ b/section_2/cis_2.4/cis_2.4.2.1.yml
@@ -4,7 +4,7 @@
   {{ if .Vars.ubtu22cis_rule_2_4_2_1 }}
 file:
   at_deny_absent:
-    title: 2.4.2.1 | Ensure at is restricted to authorized users
+    title: 2.4.2.1 | Ensure access to at is configured
     path: /etc/at.deny
     exists: false
     meta:
@@ -16,7 +16,7 @@ file:
       - AC-3
       - MP-2
   /etc/at.allow:
-    title: 2.4.2.1 | Ensure at is restricted to authorized users
+    title: 2.4.2.1 | Ensure access to at is configured
     exists: true
     owner: root
     group: root

--- a/section_3/cis_3.1/cis_3.1.1.yml
+++ b/section_3/cis_3.1/cis_3.1.1.yml
@@ -33,7 +33,7 @@ command:
       - CM-7
     {{ end }}
     {{ if eq .Vars.ubtu22cis_ipv6_disable "sysctl" }}
- file:
+file:
   ipv6_disabled:
     title: 3.1.1 | Ensure IPv6 status is identified | sysctl all disable
     path: /proc/sys/net/ipv6/conf/all/disable_ipv6
@@ -43,7 +43,7 @@ command:
     meta:
       server: 2
       workstation: 2
-      CIS_ID: 3.3.1
+      CIS_ID: 3.1.1
       NIST800-53R5:
       - CM-7
       {{ end }}

--- a/section_3/cis_3.1/cis_3.1.2.yml
+++ b/section_3/cis_3.1/cis_3.1.2.yml
@@ -4,11 +4,12 @@
   {{ if .Vars.ubtu22cis_rule_3_1_2 }}
 command:
   wireless_disabled:
-    title: 3.1.2 | Ensure wireless interfaces are disabled
+    title: 3.1.2 | Ensure wireless interfaces are not available
     exit-status: 0
-    exec: wifi_mod_list=$(find /lib/modules/$(uname -r)/kernel/drivers/net/wireless -name '*.ko' -printf '%f ' | sed 's/\.ko//g') && missing=$(printf '%s\n' $wifi_mod_list | grep -wFxv -f <(grep -oE '\b[[:alnum:]_-]+\b' /etc/modprobe.d/blacklist-wireless.conf | sort -u)); echo $missing
+    exec: "find /sys/class/net/*/wireless -type d 2>/dev/null | sed 's|/wireless$||' | while read iface; do cat \"$iface/operstate\" 2>/dev/null; done | grep -qv '^down$' && echo FAIL || echo OK"
     stdout:
-    - '!/^.*/'
+    - '/^OK/'
+    - '!/^FAIL/'
     meta:
       server: 1
       workstation: 2

--- a/section_3/cis_3.3.1/cis_3.3.1.16.yml
+++ b/section_3/cis_3.3.1/cis_3.3.1.16.yml
@@ -18,7 +18,7 @@ kernel-param:
       - CCI-000366
 command:
   ipv4_all_log_martians:
-    title: 3.3.1.16 | Ensure suspicious packets are logged | live ipv4 all
+    title: 3.3.1.16 | Ensure net.ipv4.conf.all.log_martians is configured | live ipv4 all
     exec: grep net.ipv4.conf.all.log_martians /etc/sysctl.conf /etc/sysctl.d/*.conf /run/sysctl.d/*.conf /usr/local/lib/sysctl.d/*.conf /usr/lib/sysctl.d/*.conf /lib/sysctl.d/*.conf
     exit-status:
       or:

--- a/section_3/cis_3.3.1/cis_3.3.1.18.yml
+++ b/section_3/cis_3.3.1/cis_3.3.1.18.yml
@@ -19,7 +19,7 @@ kernel-param:
       - CCI-002385
 command:
   ipv4_tcp_syn_cookies:
-    title: 3.3.1.18 | Ensure TCP SYN Cookies is enabled | live ipv4
+    title: 3.3.1.18 | Ensure net.ipv4.tcp_syncookies is configured | live ipv4
     exec: grep net.ipv4.tcp_syncookies /etc/sysctl.conf /etc/sysctl.d/*.conf /run/sysctl.d/*.conf /usr/local/lib/sysctl.d/*.conf /usr/lib/sysctl.d/*.conf /lib/sysctl.d/*.conf
     exit-status:
       or:

--- a/section_3/cis_3.3.1/cis_3.3.1.3.yml
+++ b/section_3/cis_3.3.1/cis_3.3.1.3.yml
@@ -11,7 +11,7 @@ kernel-param:
       server: 1
       workstation: 1
       CIS_ID:
-      - 3.3.1.2
+      - 3.3.1.3
       NIST800-53R5:
       - CM-6
       CCI:

--- a/section_3/cis_3.3.1/cis_3.3.1.4.yml
+++ b/section_3/cis_3.3.1/cis_3.3.1.4.yml
@@ -4,7 +4,7 @@
   {{ if .Vars.ubtu22cis_rule_3_3_1_4 }}
 kernel-param:
   net.ipv4.conf.all.send_redirects:
-    title: 3.3.1.4 | Ensure net.ipv4.conf.all.send_redirects is configured| live
+    title: 3.3.1.4 | Ensure net.ipv4.conf.all.send_redirects is configured
     value: '0'
     name: net.ipv4.conf.all.send_redirects
     meta:

--- a/section_3/cis_3.3.1/cis_3.3.1.6.yml
+++ b/section_3/cis_3.3.1/cis_3.3.1.6.yml
@@ -4,21 +4,21 @@
   {{ if .Vars.ubtu22cis_rule_3_3_1_6 }}
 kernel-param:
   net.ipv4.icmp_ignore_bogus_error_responses:
-    title: 3.3.1.5 | Ensure net.ipv4.icmp_ignore_bogus_error_responses is configured
+    title: 3.3.1.6 | Ensure net.ipv4.icmp_ignore_bogus_error_responses is configured
     value: '1'
     name: net.ipv4.icmp_ignore_bogus_error_responses
     meta:
       server: 1
       workstation: 1
       CIS_ID:
-      - 3.3.1.5
+      - 3.3.1.6
       NIST800-53R5:
       - CM-6
       CCI:
       - CCI-000366
 command:
   ipv4_ignore_bogus:
-    title: 3.3.1.5 | Ensure bogus ICMP responses are ignored | live ipv4 all
+    title: 3.3.1.6 | Ensure net.ipv4.icmp_ignore_bogus_error_responses is configured | live ipv4 all
     exec: grep net.ipv4.icmp_ignore_bogus_error_responses /etc/sysctl.conf /etc/sysctl.d/*.conf /run/sysctl.d/*.conf /usr/local/lib/sysctl.d/*.conf /usr/lib/sysctl.d/*.conf /lib/sysctl.d/*.conf
     exit-status:
       or:
@@ -31,7 +31,7 @@ command:
       server: 1
       workstation: 1
       CIS_ID:
-      - 3.3.1.5
+      - 3.3.1.6
       NIST800-53R5:
       - CM-6
       CCI:

--- a/section_3/cis_3.3.2/cis_3.3.2.4.yml
+++ b/section_3/cis_3.3.2/cis_3.3.2.4.yml
@@ -2,24 +2,24 @@
 
 {{ if .Vars.ubtu22cis_level_1 }}
   {{ if .Vars.ubtu22cis_ipv6_required }}
-    {{ if .Vars.ubtu22cis_rule_3_3_2_3 }}
+    {{ if .Vars.ubtu22cis_rule_3_3_2_4 }}
 kernel-param:
   net.ipv6.conf.default.accept_redirects:
-    title: 3.3.2.3 | Ensure net.ipv6.conf.default.accept_redirects is configured
+    title: 3.3.2.4 | Ensure net.ipv6.conf.default.accept_redirects is configured
     value: '0'
     name: net.ipv6.conf.default.accept_redirects
     meta:
       server: 1
       workstation: 1
       CIS_ID:
-      - 3.3.2.3
+      - 3.3.2.4
       NIST800-53R5:
       - CM-6
       CCI:
       - CCI-000366
 command:
   ipv6_default_accept_redirects:
-    title: 3.3.2.3 | Ensure net.ipv6.conf.default.accept_redirects is configured | live ipv6 default
+    title: 3.3.2.4 | Ensure net.ipv6.conf.default.accept_redirects is configured | live ipv6 default
     exec: grep net.ipv6.conf.default.accept_redirects /etc/sysctl.conf /etc/sysctl.d/*.conf /run/sysctl.d/*.conf /usr/local/lib/sysctl.d/*.conf /usr/lib/sysctl.d/*.conf /lib/sysctl.d/*.conf
     exit-status:
       or:
@@ -32,7 +32,7 @@ command:
       server: 1
       workstation: 1
       CIS_ID:
-      - 3.3.2.3
+      - 3.3.2.4
       NIST800-53R5:
       - CM-6
       CCI:

--- a/section_3/cis_3.3.2/cis_3.3.2.6.yml
+++ b/section_3/cis_3.3.2/cis_3.3.2.6.yml
@@ -19,7 +19,7 @@ kernel-param:
       - CCI-000366
 command:
   ipv6_default_source_routed:
-    title: 3.3.2.5 | Ensure net.ipv6.conf.default.accept_source_route is configured | live ipv6 default
+    title: 3.3.2.6 | Ensure net.ipv6.conf.default.accept_source_route is configured | live ipv6 default
     exec: grep net.ipv6.conf.default.accept_source_route /etc/sysctl.conf /etc/sysctl.d/*.conf /run/sysctl.d/*.conf /usr/local/lib/sysctl.d/*.conf /usr/lib/sysctl.d/*.conf /lib/sysctl.d/*.conf
     exit-status:
       or:
@@ -32,7 +32,7 @@ command:
       server: 1
       workstation: 1
       CIS_ID:
-      - 3.3.2.5
+      - 3.3.2.6
       NIST800-53R5:
       - CM-6
       CCI:

--- a/section_4/cis_4.1/cis_4.1.4.yml
+++ b/section_4/cis_4.1/cis_4.1.4.yml
@@ -13,7 +13,7 @@ command:
       server: 2
       workstation: 2
       CIS_ID:
-      - 4.1.3
+      - 4.1.4
       NIST800-53R5:
       - CM-7
       CCI: CCI-000382

--- a/section_4/cis_4.1/cis_4.1.5.yml
+++ b/section_4/cis_4.1/cis_4.1.5.yml
@@ -4,7 +4,7 @@
   {{ if .Vars.ubtu22cis_rule_4_1_5 }}
 command:
   ufw_routed_default:
-    title: 4.1.5 | Ensure ufw outgoing default is configured
+    title: 4.1.5 | Ensure ufw routed default is configured
     exec: ufw status verbose | awk -F',' '$1="Default"{print $3}'
     exit-status: 0
     stdout:

--- a/section_5/cis_5.1/cis_5.1.12.yml
+++ b/section_5/cis_5.1/cis_5.1.12.yml
@@ -4,7 +4,7 @@
   {{ if .Vars.ubtu22cis_rule_5_1_12 }}
 command:
   sshd_KEX:
-    title: 5.1.12 | Ensure sshd Kex algorithms is configured
+    title: 5.1.12 | Ensure sshd KexAlgorithms is configured
     exec: sshd -T | grep -Pi -- 'kexalgorithms\h+([^#\n\r]+,)?(diffie-hellman-group1-sha1|diffie-hellman-group14-sha1|diffie-hellman-group-exchange-sha1)\b'
     exit-status:
       or:

--- a/section_5/cis_5.1/cis_5.1.15.yml
+++ b/section_5/cis_5.1/cis_5.1.15.yml
@@ -4,7 +4,7 @@
   {{ if .Vars.ubtu22cis_rule_5_1_15 }}
 command:
   sshd_MACS:
-    title: 5.1.15 | Ensure only strong MACs are used
+    title: 5.1.15 | Ensure sshd MACs are configured
     exec: sshd -T | grep -Pi -- 'macs\h+([^#\n\r]+,)?(hmac-md5|hmac-md5-96|hmac-ripemd160|hmac-sha1-96|umac-64@openssh\.com|hmac-md5-etm@openssh\.com|hmac-md5-96-etm@openssh\.com|hmac-ripemd160-etm@openssh\.com|hmac-sha1-96-etm@openssh\.com|umac-64-etm@openssh\.com|umac-128-etm@openssh\.com)\b'
     exit-status:
       or:

--- a/section_5/cis_5.1/cis_5.1.17.yml
+++ b/section_5/cis_5.1/cis_5.1.17.yml
@@ -7,10 +7,12 @@ file:
     exists: true
     contents:
     - '/(?i)^MaxSessions ([2-9]|10)/'
-    - '!/(?i)^MaxSessions (1|1[1-9]|[2-9][0-9]|[1-9]{3,})/'
+    - '!/(?i)^MaxSessions (1|1[1-9]|[2-9][0-9]|[1-9]{3,})$/'
     meta:
       server: 1
       workstation: 1
+      CIS_ID:
+      - 5.1.17
       NIST800-53R5:
       - CM-1
       - CM-2

--- a/section_5/cis_5.1/cis_5.1.17.yml
+++ b/section_5/cis_5.1/cis_5.1.17.yml
@@ -2,7 +2,7 @@
   {{ if .Vars.ubtu22cis_rule_5_1_17 }}
 file:
   ssh_maxsessions:
-    title: 5.1.17 | Ensure SSH MaxSessions is limited
+    title: 5.1.17 | Ensure sshd MaxSessions is configured
     path: /etc/ssh/sshd_config
     exists: true
     contents:

--- a/section_5/cis_5.1/cis_5.1.19.yml
+++ b/section_5/cis_5.1/cis_5.1.19.yml
@@ -4,7 +4,7 @@
   {{ if .Vars.ubtu22cis_rule_5_1_19 }}
 file:
   ssh_empty_passwd:
-    title: 5.1.19 | Ensure SSH PermitEmptyPasswords is configured
+    title: 5.1.19 | Ensure sshd PermitEmptyPasswords is disabled
     path: /etc/ssh/sshd_config
     exists: true
     contents:

--- a/section_5/cis_5.1/cis_5.1.20.yml
+++ b/section_5/cis_5.1/cis_5.1.20.yml
@@ -4,7 +4,7 @@
   {{ if .Vars.ubtu22cis_rule_5_1_20 }}
 file:
   ssh_permit_root:
-    title: 5.1.20 | Ensure sshd PermitRootLogin is configured
+    title: 5.1.20 | Ensure sshd PermitRootLogin is disabled
     path: /etc/ssh/sshd_config
     exists: true
     contents:

--- a/section_5/cis_5.1/cis_5.1.22.yml
+++ b/section_5/cis_5.1/cis_5.1.22.yml
@@ -4,7 +4,7 @@
   {{ if .Vars.ubtu22cis_rule_5_1_22 }}
 file:
   ssh_usepam:
-    title: 5.1.22 | Ensure SSH PAM is enabled
+    title: 5.1.22 | Ensure sshd UsePAM is enabled
     path: /etc/ssh/sshd_config
     exists: true
     contents:

--- a/section_5/cis_5.1/cis_5.1.22.yml
+++ b/section_5/cis_5.1/cis_5.1.22.yml
@@ -8,7 +8,7 @@ file:
     path: /etc/ssh/sshd_config
     exists: true
     contents:
-    - '/(?i)^UsePAM yes'
+    - '/(?i)^UsePAM yes/'
     - '!/(?i)^UsePAM no/'
     meta:
       server: 1

--- a/section_5/cis_5.1/cis_5.1.5.yml
+++ b/section_5/cis_5.1/cis_5.1.5.yml
@@ -23,7 +23,7 @@ file:
       - IA-5
 command:
   ssh_configd_banner:
-    title: 5.1.5 | Ensure SSH warning banner configured | conf.d banner settings
+    title: 5.1.5 | Ensure sshd Banner is configured | conf.d banner settings
     exec: grep -Eis '^\s*Banner\s+"?none\b'/etc/ssh/sshd_config.d/*.conf
     exit-status:
       or:

--- a/section_5/cis_5.1/cis_5.1.7.yml
+++ b/section_5/cis_5.1/cis_5.1.7.yml
@@ -4,7 +4,7 @@
   {{ if .Vars.ubtu22cis_rule_5_1_7 }}
 file:
   sshd_clientalive:
-    title: 5.1.7 | Ensure sshd ClientAliveInterval and CLientAliveCountMax are configured
+    title: 5.1.7 | Ensure sshd ClientAliveInterval and ClientAliveCountMax are configured
     path: /etc/ssh/sshd_config
     exists: true
     contents:

--- a/section_5/cis_5.2/cis_5.2.4.yml
+++ b/section_5/cis_5.2/cis_5.2.4.yml
@@ -4,7 +4,7 @@
   {{ if .Vars.ubtu22cis_rule_5_2_4 }}
 command:
   nopasswd_sudoers_d:
-    title: 5.2.4 | Ensure users must provide password for privilege escalation
+    title: 5.2.4 | Ensure users must provide password for escalation
     exec: grep -R NOPASSWD /etc/sudoers /etc/sudoers.d/* | grep -v '.*\:#'
     exit-status:
       or:

--- a/section_5/cis_5.2/cis_5.2.6.yml
+++ b/section_5/cis_5.2/cis_5.2.6.yml
@@ -4,7 +4,7 @@
   {{ if .Vars.ubtu22cis_rule_5_2_6 }}
 command:
   sudo_timeout:
-    title: 5.2.6 | Ensure sudo authentication timeout is configured correctly
+    title: 5.2.6 | Ensure sudo timestamp_timeout is configured
     exec: grep -rP "timestamp_timeout=\K[0-9]*" /etc/sudoers*
     exit-status: 0
     stdout:

--- a/section_5/cis_5.3.1/cis_5.3.1.3.yml
+++ b/section_5/cis_5.3.1/cis_5.3.1.3.yml
@@ -7,8 +7,6 @@ package:
     title: 5.3.1.3 | Ensure latest version of libpam-pwquality is installed
     name: libpam-pwquality
     installed: true
-    versions:
-      - 'jammy 1.4.4-1build1'
     meta:
       server: 1
       workstation: 1

--- a/section_5/cis_5.3.3.1/cis_5.3.3.1.3.yml
+++ b/section_5/cis_5.3.3.1/cis_5.3.3.1.3.yml
@@ -4,7 +4,7 @@
   {{ if .Vars.ubtu22cis_rule_5_3_3_1_3 }}
 file:
   faillock_even_root:
-    title: 5.3.3.1.3 | Ensure password unlock time is configured
+    title: 5.3.3.1.3 | Ensure password failed attempts lockout includes root account
     path: /etc/security/faillock.conf
     exists: true
     contents:
@@ -17,7 +17,7 @@ file:
       NIST800-53R5: NA
 command:
   faillock_even_root_removed:
-    title: 5.3.3.1.3 | Ensure password unlock time is configured
+    title: 5.3.3.1.3 | Ensure password failed attempts lockout includes root account
     exec: grep -Pl -- '\bpam_faillock\.so\h+([^#\n\r]+\h+)?(even_deny_root|root_unlock_time)' /usr/share/pam-configs/*
     exit-status: 1
     stdout:

--- a/section_5/cis_5.3.3.2/cis_5.3.3.2.8.yml
+++ b/section_5/cis_5.3.3.2/cis_5.3.3.2.8.yml
@@ -4,7 +4,7 @@
   {{ if .Vars.ubtu22cis_rule_5_3_3_2_8 }}
 command:
   password_quality_enforce_root:
-    title: 5.3.3.2.8 | Ensure password quality checking is enforced
+    title: 5.3.3.2.8 | Ensure password quality is enforced for the root user
     exec: grep -Psi -- '^\s*enforce_for_root\b' /etc/security/pwquality.conf /etc/security/pwquality.conf.d/*.conf
     exit-status:
       or:

--- a/section_5/cis_5.4.1/cis_5.4.1.1.yml
+++ b/section_5/cis_5.4.1/cis_5.4.1.1.yml
@@ -24,7 +24,7 @@ file:
       - IA-5
 command:
   users_max_pw_expire:
-    title: 5.4.1.1 | Ensure password expiration is 365 days or less | user_check
+    title: 5.4.1.1 | Ensure password expiration is configured | user_check
     exec: "awk -F: '(/^[^:]+:[^!*]/)  {print $5}' /etc/shadow"
     exit-status:
       or:

--- a/section_5/cis_5.4.1/cis_5.4.1.2.yml
+++ b/section_5/cis_5.4.1/cis_5.4.1.2.yml
@@ -19,7 +19,7 @@ file:
       NIST800-53R5: IA-5
 command:
   users_min_pw_expire:
-    title: 5.4.1.1 | Ensure minimum password days is configured | user_check
+    title: 5.4.1.2 | Ensure minimum password days is configured | user_check
     exec: "awk -F: '(/^[^:]+:[^!*]/) {print $4}' /etc/shadow"
     exit-status:
       or:

--- a/section_5/cis_5.4.2/cis_5.4.2.5.yml
+++ b/section_5/cis_5.4.2/cis_5.4.2.5.yml
@@ -4,7 +4,7 @@
   {{ if .Vars.ubtu22cis_rule_5_4_2_5 }}
 command:
   root_path_check:
-    title: 5.4.2.5 | Ensure root path Integrity
+    title: 5.4.2.5 | Ensure root path integrity
     exec: "/bin/bash --login -c 'env | grep ^PATH=' | sed -e 's/PATH=//' -e 's/::/:/' -e 's/:$//' -e 's/:/\\n/g'"
     exit-status: 0
     stdout:

--- a/section_5/cis_5.4.2/cis_5.4.2.8.yml
+++ b/section_5/cis_5.4.2/cis_5.4.2.8.yml
@@ -4,16 +4,14 @@
   {{ if .Vars.ubtu22cis_rule_5_4_2_8 }}
 command:
   user_accts_valid_shell:
-    title: 5.4.2.8 | Ensure system accounts do not have a valid login shell
+    title: 5.4.2.8 | Ensure accounts without a valid login shell are locked
     exec: |
-      l_valid_shells="^($(awk -F\/ '$NF != "nologin" {print}' /etc/shells | sed -rn '/^\//{s,/,\\\\/,g;p}' | paste -s -d '|' - ))$"
+      l_valid_shells="^($(awk -F/ '$NF != "nologin" {print}' /etc/shells | sed -rn '/^\//{s,/,\\/,g;p}' | paste -s -d '|' -))$"
+      awk -v pat="$l_valid_shells" -F: '($1 != "root" && $(NF) !~ pat) {print $1}' /etc/passwd |
       while IFS= read -r l_user; do
-          passwd -S "$l_user" | awk '$2 !~ /^L/ {print "Account: \"" $1 "\" does not have a valid login shell and is not locked"}'
-      done < <(awk -v pat="$l_valid_shells" -F: '($1 != "root" && $(NF) !~ pat) {print $1}' /etc/passwd)
-    exit-status:
-      or:
-      - 0
-      - 1
+      passwd -S "$l_user" | awk '$2 !~ /^L/ {print "Account: \"" $1 "\" does not have a valid login shell and is not locked"}'
+      done
+    exit-status: 0
     stdout:
     - '!/./'
     meta:

--- a/section_6/cis_6.1.1.1/cis_6.1.1.1.6.yml
+++ b/section_6/cis_6.1.1.1/cis_6.1.1.1.6.yml
@@ -4,7 +4,7 @@
   {{ if .Vars.ubtu22cis_rule_6_1_1_1_6 }}
 command:
   compress_journald_conf:
-    title: 6.1.1.1.6 | Ensure journald is configured to compress large log files
+    title: 6.1.1.1.6 | Ensure journald Compress is configured
     exec: grep -i Compress /etc/systemd/journald.conf /etc/systemd/journald.conf.d/*.conf
     exit-status:
       or:

--- a/section_6/cis_6.1.1.2/cis_6.1.1.2.2.yml
+++ b/section_6/cis_6.1.1.2/cis_6.1.1.2.2.yml
@@ -5,7 +5,7 @@
     {{ if not .Vars.ubtu22cis_is_syslog_server }}
 file:
   journal_remote_configured:
-    title: 6.1.1.2.2 | Ensure systemd-journal-remote authentication is configured
+    title: 6.1.1.2.2 | Ensure systemd-journal-upload authentication is configured
     path: /etc/systemd/journal-upload.conf
     exists: true
     contents:

--- a/section_6/cis_6.1.1.2/cis_6.1.1.2.2.yml
+++ b/section_6/cis_6.1.1.2/cis_6.1.1.2.2.yml
@@ -10,9 +10,9 @@ file:
     exists: true
     contents:
     - '/^URL=/'
-    - '/ServerKeyFile=.*.pem'
-    - '/ServerCertificateFile=.*.pem'
-    - '/TrustedCertificateFile=.*.pem'
+    - '/ServerKeyFile=.*\.pem/'
+    - '/ServerCertificateFile=.*\.pem/'
+    - '/TrustedCertificateFile=.*\.pem/'
     meta:
       server: 1
       workstation: 1

--- a/section_6/cis_6.1.2/cis_6.1.2.5.yml
+++ b/section_6/cis_6.1.2/cis_6.1.2.5.yml
@@ -4,7 +4,7 @@
   {{ if .Vars.ubtu22cis_rule_6_1_2_5 }}
 file:
   /etc/rsyslog.conf:
-    title: 6.1.2.5 | Ensure logging is configured
+    title: 6.1.2.5 | Ensure rsyslog logging is configured
     exists: true
     contents:
     - '/^\*.emerg\s+:omusrmsg:\*/'

--- a/section_6/cis_6.1.2/cis_6.1.2.6.yml
+++ b/section_6/cis_6.1.2/cis_6.1.2.6.yml
@@ -5,7 +5,7 @@
     {{ if not .Vars.ubtu22cis_remote_log_server }}
 command:
   remote_syslog:
-    title: 6.1.2.6 | Ensure rsyslog is configured to send logs to a remote host
+    title: 6.1.2.6 | Ensure rsyslog is configured to send logs to a remote log host
     exec: 'grep -E "action.*omfwd.*target" /etc/rsyslog.conf /etc/rsyslog.d/*.conf'
     exit-status:
       or:

--- a/section_6/cis_6.1.2/cis_6.1.2.7.yml
+++ b/section_6/cis_6.1.2/cis_6.1.2.7.yml
@@ -6,7 +6,7 @@
     {{ if not .Vars.ubtu22cis_remote_log_server }}
 command:
   local_syslog_module:
-    title: 6.1.2.7 | Ensure rsyslog is not configured to recieve logs from a remote client | module
+    title: 6.1.2.7 | Ensure rsyslog is not configured to receive logs from a remote client | module
     exec: grep "imtcp" /etc/rsyslog.conf /etc/rsyslog.d/*.conf | grep -Ev ":#|port="
     exit-status:
       or:
@@ -26,7 +26,7 @@ command:
       - AU-12
       - CM-6
   local_syslog_input:
-    title: 6.1.2.7 | Ensure rsyslog is not configured to recieve logs from a remote client | server/port
+    title: 6.1.2.7 | Ensure rsyslog is not configured to receive logs from a remote client | server/port
     exec: grep -E "imtcp\" port|InputTCPServerRun" /etc/rsyslog.conf /etc/rsyslog.d/*.conf | grep -v ":#"
     exit-status:
       or:

--- a/section_6/cis_6.1.2/cis_6.1.2.8.yml
+++ b/section_6/cis_6.1.2/cis_6.1.2.8.yml
@@ -4,7 +4,7 @@
   {{ if .Vars.ubtu22cis_rule_6_1_2_8 }}
 command:
   rsyslog_logrotate:
-    title: 6.1.2.8 | Ensure rsyslog logrotate is configured | Manual check required
+    title: 6.1.2.8 | Ensure logrotate is configured | Manual check required
     exec: echo "Manual"
     exit-status: 0
     stdout:

--- a/section_6/cis_6.2.1/cis_6.2.1.1.yml
+++ b/section_6/cis_6.2.1/cis_6.2.1.1.yml
@@ -18,7 +18,7 @@ package:
       - AU-12
       - SI-5
   audispd-plugins:
-    title: 6.2.1.1 | Ensure auditd is installed | audispd-plugins pkg
+    title: 6.2.1.1 | Ensure auditd packages are installed | audispd-plugins pkg
     name: audispd-plugins
     installed: true
     meta:

--- a/section_6/cis_6.2.1/cis_6.2.1.4.yml
+++ b/section_6/cis_6.2.1/cis_6.2.1.4.yml
@@ -4,7 +4,7 @@
   {{ if .Vars.ubtu22cis_rule_6_2_1_4 }}
 command:
   auditd_grub_backlog:
-    title: 6.2.1.4 | Ensure audit_backlog_limit is sufficient | bootloader file
+    title: 6.2.1.4 | Ensure audit_backlog_limit is configured | bootloader file
     exec: grep "^\s*linux" /boot/grub/grub.cfg | grep -Evc "audit_backlog_limit="
     exit-status: 1
     stdout:
@@ -20,7 +20,7 @@ command:
       - AU-12
 file:
   grub_audit_backlog:
-    title: 6.2.1.4 | Ensure audit_backlog_limit is sufficient | default grub
+    title: 6.2.1.4 | Ensure audit_backlog_limit is configured | default grub
     path: /etc/default/grub
     exists: true
     contents:

--- a/section_6/cis_6.2.2/cis_6.2.2.2.yml
+++ b/section_6/cis_6.2.2/cis_6.2.2.2.yml
@@ -8,7 +8,7 @@ command:
     exec: grep -E "^max_log_file_action" /etc/audit/auditd.conf
     exit-status: 0
     stdout:
-    - 'max_log_file_action\s*=\s*{{ .Vars.ubtu22cis_auditd.max_log_file_action }}'
+    - '/max_log_file_action\s*=\s*{{ .Vars.ubtu22cis_auditd.max_log_file_action }}/'
     meta:
       server: 2
       workstation: 2

--- a/section_6/cis_6.2.3/cis_6.2.3.15.yml
+++ b/section_6/cis_6.2.3/cis_6.2.3.15.yml
@@ -4,7 +4,7 @@
   {{ if .Vars.ubtu22cis_rule_6_2_3_15 }}
 command:
   chcon_module_cnf:
-    title: 6.2.3.15 | Ensure successful and unsuccessful attempts to use the chcon command are recorded | Config
+    title: 6.2.3.15 | Ensure successful and unsuccessful attempts to use the chcon command are collected | Config
     exec: grep chcon /etc/audit/rules.d/*.rules
     exit-status: 0
     stdout:
@@ -19,7 +19,7 @@ command:
       - AU-12
       - SI-5
   chcon_module_live:
-    title: 6.2.3.15 | Ensure successful and unsuccessful attempts to use the chcon command are recorded | Live
+    title: 6.2.3.15 | Ensure successful and unsuccessful attempts to use the chcon command are collected | Live
     exec: auditctl -l | grep chcon
     exit-status: 0
     stdout:

--- a/section_6/cis_6.2.3/cis_6.2.3.16.yml
+++ b/section_6/cis_6.2.3/cis_6.2.3.16.yml
@@ -4,7 +4,7 @@
   {{ if .Vars.ubtu22cis_rule_6_2_3_16 }}
 command:
   setfacl_module_cnf:
-    title: 6.2.3.16 | Ensure successful and unsuccessful attempts to use the setfacl command are recorded | Config
+    title: 6.2.3.16 | Ensure successful and unsuccessful attempts to use the setfacl command are collected | Config
     exec: grep setfacl /etc/audit/rules.d/*.rules
     exit-status: 0
     stdout:
@@ -19,7 +19,7 @@ command:
       - AU-12
       - SI-5
   setfacl_module_live:
-    title: 6.2.3.16 | Ensure successful and unsuccessful attempts to use the setfacl command are recorded | Live
+    title: 6.2.3.16 | Ensure successful and unsuccessful attempts to use the setfacl command are collected | Live
     exec: auditctl -l | grep setfacl
     exit-status: 0
     stdout:

--- a/section_6/cis_6.2.3/cis_6.2.3.17.yml
+++ b/section_6/cis_6.2.3/cis_6.2.3.17.yml
@@ -4,7 +4,7 @@
   {{ if .Vars.ubtu22cis_rule_6_2_3_17 }}
 command:
   chacl_module_cnf:
-    title: 6.2.3.17 | Ensure successful and unsuccessful attempts to use the chacl command are recorded | Config
+    title: 6.2.3.17 | Ensure successful and unsuccessful attempts to use the chacl command are collected | Config
     exec: grep chacl /etc/audit/rules.d/*.rules
     exit-status: 0
     stdout:
@@ -19,7 +19,7 @@ command:
       - AU-12
       - SI-5
   chacl_module_live:
-    title: 6.2.3.17 | Ensure successful and unsuccessful attempts to use the chacl command are recorded | Live
+    title: 6.2.3.17 | Ensure successful and unsuccessful attempts to use the chacl command are collected | Live
     exec: auditctl -l | grep chacl
     exit-status: 0
     stdout:

--- a/section_6/cis_6.2.3/cis_6.2.3.18.yml
+++ b/section_6/cis_6.2.3/cis_6.2.3.18.yml
@@ -4,7 +4,7 @@
   {{ if .Vars.ubtu22cis_rule_6_2_3_18 }}
 command:
   usermod_module_cnf:
-    title: 6.2.3.18 | Ensure successful and unsuccessful attempts to use the usermod command are recorded | Config
+    title: 6.2.3.18 | Ensure successful and unsuccessful attempts to use the usermod command are collected | Config
     exec: grep usermod /etc/audit/rules.d/*.rules
     exit-status: 0
     stdout:
@@ -19,7 +19,7 @@ command:
       - AU-12
       - SI-5
   usermod_module_live:
-    title: 6.2.3.18 | Ensure successful and unsuccessful attempts to use the usermod command are recorded | Live
+    title: 6.2.3.18 | Ensure successful and unsuccessful attempts to use the usermod command are collected | Live
     exec: auditctl -l | grep usermod
     exit-status: 0
     stdout:

--- a/section_6/cis_6.2.3/cis_6.2.3.19.yml
+++ b/section_6/cis_6.2.3/cis_6.2.3.19.yml
@@ -4,7 +4,7 @@
   {{ if .Vars.ubtu22cis_rule_6_2_3_19 }}
 command:
   auditd_module_cnf:
-    title: 6.2.3.19 | Ensure kernel module loading and unloading is collected | Config
+    title: 6.2.3.19 | Ensure kernel module loading unloading and modification is collected | Config
     exec: grep kernel_module /etc/audit/rules.d/*.rules
     exit-status: 0
     stdout:
@@ -19,7 +19,7 @@ command:
       - AU-3
       - CM-6
   auditd_admin_module_live:
-    title: 6.2.3.19 | Ensure kernel module loading and unloading is collected | Live
+    title: 6.2.3.19 | Ensure kernel module loading unloading and modification is collected | Live
     exec: auditctl -l | grep kernel_module
     exit-status: 0
     stdout:

--- a/section_6/cis_6.2.3/cis_6.2.3.21.yml
+++ b/section_6/cis_6.2.3/cis_6.2.3.21.yml
@@ -4,7 +4,7 @@
   {{ if .Vars.ubtu22cis_rule_6_2_3_21 }}
 command:
   auditd_config_match:
-    title: 6.2.3.21 | Ensure the audit configuration is immutable
+    title: 6.2.3.21 | Ensure the running and on disk configuration is the same
     exec: augenrules --check
     exit-status: 0
     stdout:

--- a/section_6/cis_6.2.3/cis_6.2.3.4.yml
+++ b/section_6/cis_6.2.3/cis_6.2.3.4.yml
@@ -9,7 +9,7 @@ command:
     exit-status: 0
     stdout:
     - '-a always,exit -F arch=b64 -S adjtimex,settimeofday -k time-change'
-    - '-a always,exit -F arch=b32 -S adjtimex,settimeofday-k time-change'
+    - '-a always,exit -F arch=b32 -S adjtimex,settimeofday -k time-change'
     - '-a always,exit -F arch=b64 -S clock_settime -F a0=0x0 -k time-change'
     - '-a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -k time-change'
     - '-w /etc/localtime -p wa -k time-change'

--- a/section_6/cis_6.2.3/cis_6.2.3.6.yml
+++ b/section_6/cis_6.2.3/cis_6.2.3.6.yml
@@ -4,7 +4,7 @@
   {{ if .Vars.ubtu22cis_rule_6_2_3_6 }}
 command:
   auditd_priv_cmds_cnf:
-    title: 6.2.3.6 | Ensure use of privileged commands is collected | Config
+    title: 6.2.3.6 | Ensure use of privileged commands are collected | Config
     exec: grep delete /etc/audit/rules.d/*.rules
     exit-status: 0
     stdout:

--- a/section_6/cis_6.2.4/cis_6.2.4.3.yml
+++ b/section_6/cis_6.2.4/cis_6.2.4.3.yml
@@ -17,7 +17,7 @@ command:
       NIST800-53R5:
       - AU-3
   audit_logfile_group:
-    title: 6.2.4.3 | Ensure only authorized groups are assigned ownership of audit log files
+    title: 6.2.4.3 | Ensure audit log files group owner is configured
     exec: for file in `grep ^log_file /etc/audit/auditd.conf | awk '{ print $NF }'`; do stat -Lc " %n_%G" $file; done
     exit-status: 0
     stdout:

--- a/section_7/cis_7.1/cis_7.1.1.yml
+++ b/section_7/cis_7.1/cis_7.1.1.yml
@@ -4,7 +4,7 @@
   {{ if .Vars.ubtu22cis_rule_7_1_1 }}
 file:
   passwd_perms:
-    title: 7.1.1 | Ensure permissions on /etc/passwd are configured
+    title: 7.1.1 | Ensure access to /etc/passwd is configured
     path: /etc/passwd
     exists: true
     owner: root

--- a/section_7/cis_7.1/cis_7.1.10.yml
+++ b/section_7/cis_7.1/cis_7.1.10.yml
@@ -4,7 +4,7 @@
   {{ if .Vars.ubtu22cis_rule_7_1_10 }}
 file:
   etc_security_opasswd_perms:
-    title: 7.1.10 | Ensure permissions on /etc/security/opasswd are configured
+    title: 7.1.10 | Ensure access to /etc/security/opasswd is configured
     path: /etc/security/opasswd
     exists:
       or:

--- a/section_7/cis_7.1/cis_7.1.2.yml
+++ b/section_7/cis_7.1/cis_7.1.2.yml
@@ -4,7 +4,7 @@
   {{ if .Vars.ubtu22cis_rule_7_1_2 }}
 file:
   passwd-_perms:
-    title: 7.1.2 | Ensure permissions on /etc/passwd- are configured
+    title: 7.1.2 | Ensure access to /etc/passwd- is configured
     path: /etc/passwd
     exists: true
     owner: root

--- a/section_7/cis_7.1/cis_7.1.3.yml
+++ b/section_7/cis_7.1/cis_7.1.3.yml
@@ -4,7 +4,7 @@
   {{ if .Vars.ubtu22cis_rule_7_1_3 }}
 file:
   group_perms:
-    title: 7.1.3 | Ensure permissions on /etc/group are configured
+    title: 7.1.3 | Ensure access to /etc/group is configured
     path: /etc/group
     exists: true
     owner: root

--- a/section_7/cis_7.1/cis_7.1.4.yml
+++ b/section_7/cis_7.1/cis_7.1.4.yml
@@ -4,7 +4,7 @@
   {{ if .Vars.ubtu22cis_rule_7_1_4 }}
 file:
   group-_perms:
-    title: 7.1.4 | Ensure permissions on /etc/group- are configured
+    title: 7.1.4 | Ensure access to /etc/group- is configured
     path: /etc/group-
     exists: true
     owner: root

--- a/section_7/cis_7.1/cis_7.1.5.yml
+++ b/section_7/cis_7.1/cis_7.1.5.yml
@@ -4,7 +4,7 @@
   {{ if .Vars.ubtu22cis_rule_7_1_5 }}
 file:
   shadow_perms:
-    title: 7.1.5 | Ensure permissions on /etc/shadow are configured
+    title: 7.1.5 | Ensure access to /etc/shadow is configured
     path: /etc/shadow
     exists: true
     owner: root

--- a/section_7/cis_7.1/cis_7.1.6.yml
+++ b/section_7/cis_7.1/cis_7.1.6.yml
@@ -4,7 +4,7 @@
   {{ if .Vars.ubtu22cis_rule_7_1_6 }}
 file:
   shadow-_perms:
-    title: 7.1.6 | Ensure permissions on /etc/shadow- are configured
+    title: 7.1.6 | Ensure access to /etc/shadow- is configured
     path: /etc/shadow-
     exists: true
     owner: root

--- a/section_7/cis_7.1/cis_7.1.7.yml
+++ b/section_7/cis_7.1/cis_7.1.7.yml
@@ -4,7 +4,7 @@
   {{ if .Vars.ubtu22cis_rule_7_1_7 }}
 file:
   gshadow_perms:
-    title: 7.1.7 | Ensure permissions on /etc/gshadow are configured
+    title: 7.1.7 | Ensure access to /etc/gshadow is configured
     path: /etc/gshadow
     exists: true
     owner: root

--- a/section_7/cis_7.1/cis_7.1.8.yml
+++ b/section_7/cis_7.1/cis_7.1.8.yml
@@ -4,7 +4,7 @@
   {{ if .Vars.ubtu22cis_rule_7_1_8 }}
 file:
   gshadow-_perms:
-    title: 7.1.8 | Ensure permissions on /etc/gshadow- are configured
+    title: 7.1.8 | Ensure access to /etc/gshadow- is configured
     path: /etc/gshadow-
     exists: true
     owner: root

--- a/section_7/cis_7.1/cis_7.1.9.yml
+++ b/section_7/cis_7.1/cis_7.1.9.yml
@@ -4,7 +4,7 @@
   {{ if .Vars.ubtu22cis_rule_7_1_9 }}
 file:
   etc_shells_perms:
-    title: 7.1.9 | Ensure permissions on /etc/shells are configured
+    title: 7.1.9 | Ensure access to /etc/shells is configured
     path: /etc/shells
     exists: true
     owner: root

--- a/section_7/cis_7.2/cis_7.2.3.yml
+++ b/section_7/cis_7.2/cis_7.2.3.yml
@@ -5,13 +5,10 @@
 command:
   passwd_group_exist:
     title: 7.2.3 | Ensure all groups in /etc/passwd exist in /etc/group
-    exec: "awk -F: '{print $4}' /etc/passwd |sort -u > /tmp/uid && awk -F: '{print $3}' /etc/group| sort -u> /tmp/gid && comm -23 /tmp/uid /tmp/gid && rm -f /tmp/uid /tmp/gid"
-    exit-status:
-      or:
-      - 0
-      - 1
+    exec: "awk -F: 'NR==FNR{gid[$3];next} !($4 in gid){print $4}' /etc/group /etc/passwd | sort -u"
+    exit-status: 0
     stdout:
-    - '!/.*/'
+    - '!/./'
     meta:
       server: 1
       workstation: 1

--- a/vars/CIS.yml
+++ b/vars/CIS.yml
@@ -513,7 +513,7 @@ ubtu22cis_dconf_db_name: local
 # Options are
 # true to leave installed if exists not changes take place
 # false - this removes the package
-# mask - if a dependancy for product so cannot be removed
+# mask - if a dependency for product so cannot be removed
 # Server Services
 ubtu22cis_autofs_services: false
 ubtu22cis_autofs_mask: true
@@ -607,7 +607,7 @@ ubtu22cis_ipv6_disable: grub
 # Options are
 # true to leave installed if exists not changes take place
 # false - this removes the package
-# mask - if a dependancy for product so cannot be removed
+# mask - if a dependency for product so cannot be removed
 ubtu22cis_bluetooth_service: false
 ubtu22cis_bluetooth_mask: false
 


### PR DESCRIPTION
- v3.00_aug26 branch
  - 6.1.3.x tasks never imported, control 6.1.3.1 never ran
  - pam_unix.j2 rule toggles used dot notation, 5.3.3.4.3 and 5.3.3.4.4 did nothing
  - grub user assert regated on set_boot_pass, blocked the play at defaults
  - prelim: removed RHEL8 distribution version assert
  - 2.1.18: unit typo ngnix.service corrected
  - 2.3.3.3: package and unit ntpd corrected to ntp
  - 6.1.1.2.4: journal-remote mask given package presence ternary
  - 1.5.5 and 5.3.3.3.1: sub-task IDs and titles corrected
  - Audit template renamed to lockdown_audit.yml.j2
  - Bridge: remote log server boolean and warning banner mappings fixed
  - Container gating moved to is_container.yml, apparmor, ipv6, auditd, ptrace, timesync added
  - Molecule: rule overrides and grub stub removed, role referenced by path
  - Goss version updated to krameff v0.5.0, checksums verified
  - Audit variables moved from defaults to vars/audit.yml
  - Titles updated for alignment
  - Bracket notation applied, symbolic modes, failed_when before register
  - Orphan chrony.conf.j2 and ntp.conf.j2 removed
  - Public only workflows removed, actions/checkout bumped
  - README emoticons removed, badge updated to x.com
  - titles updated

**How has this been tested?:**
Manually

